### PR TITLE
Don't write lines into config file if they are already there.

### DIFF
--- a/startx.sh
+++ b/startx.sh
@@ -9,8 +9,11 @@
 ## development mode (disables X-Pack security)
 
 if [ "$DEVELOPMENT_MODE" == "1" ]; then
-	echo xpack.security.enabled: false >> ${ES_PATH_CONF}/elasticsearch.yml
-	echo xpack.security.enabled: false >> ${KIBANA_HOME}/config/kibana.yml
+	if ! grep -q xpack.security.enabled ${ES_PATH_CONF}/elasticsearch.yml
+	then
+		echo xpack.security.enabled: false >> ${ES_PATH_CONF}/elasticsearch.yml
+		echo xpack.security.enabled: false >> ${KIBANA_HOME}/config/kibana.yml
+	fi
 	/usr/local/bin/start.sh
 	exit 0
 fi


### PR DESCRIPTION
If you start a container "elkx" with DEVELOPMENT_MODE=1, and you run "docker stop elkx" followed by "docker start elkx", on the second startup the "xpack.security.enabled: false" is written a second time into the configuration file, which causes elasticsearch to fail to start.  This guard just checks to see if it's there, and if so, avoids writing it again.
