### PR TITLE
Add built-in user password to Logstash for X-Pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ In another shell, open a bash session in the running container (replacing `<name
 	Initiating the setup of reserved user elastic,kibana,logstash_system passwords.
 	You will be prompted to enter passwords as the process progresses.
 	Please confirm that you would like to continue [y/N]y
-	
-	
+
+
 	Enter password for [elastic]: changeme
 	Reenter password for [elastic]: changeme
 	Enter password for [kibana]: changeme
@@ -114,13 +114,6 @@ In another shell, open a bash session in the running container (replacing `<name
 	Changed password for user [kibana]
 	Changed password for user [logstash_system]
 	Changed password for user [elastic]
-
-Now configure monitoring for Logstash with the right users:
-
-	# cat >> /opt/logstash/config/logstash.yml
-	xpack.monitoring.elasticsearch.username: "logstash_system"
-	xpack.monitoring.elasticsearch.password: "changeme"
-	^D
 
 Stop the container, then edit the docker-compose.yml as follows:
 
@@ -160,15 +153,15 @@ Once the container has started, only Elasticsearch will be running, and the user
 
 - by manually `docker exec`-ing into the running container and [using the `setup-passwords` tool](https://www.elastic.co/guide/en/x-pack/6.0/setting-up-authentication.html#set-built-in-user-passwords) located in `$ES_HOME/bin/x-pack`,
 
-- or by manually or programmatically [using the user management REST APIs](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/security-api-users.html). 
+- or by manually or programmatically [using the user management REST APIs](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/security-api-users.html).
 
 Once all the passwords have been assigned, stop the container, and start the container in _normal mode_ as described below.
 
-### Running the container in normal mode 
+### Running the container in normal mode
 
 In order to start up and run normally, the container needs to have two users that are authorised to connect to Elasticsearch's and Kibana's interfaces (JSON and web, respectively), and their credentials must be set using the following environment variables: `ELASTICSEARCH_USER`, `ELASTICSEARCH_PASSWORD`, `KIBANA_USER`, and `KIBANA_PASSWORD`.
 
-In addition, the default Logstash configuration (in `/etc/logstash/conf.d/30-output.conf`) uses the user defined by the `LOGSTASH_USER` and `LOGSTASH_PASSWORD` environment variables to sends logs to Elasticsearch. 
+In addition, the default Logstash configuration (in `/etc/logstash/conf.d/30-output.conf`) uses the user defined by the `LOGSTASH_USER` and `LOGSTASH_PASSWORD` environment variables to sends logs to Elasticsearch.
 
 To get an idea of how this works, **in a non-production environment**, first set passwords for the built-in `elastic` and `kibana` users to `changeme` in bootstrap mode as described above, then re-run the container with:
 
@@ -195,7 +188,7 @@ To run the [example Filebeat set-up](http://elk-docker.readthedocs.io/#forwardin
 
 The `latest` image includes a development mode, which disables X-Pack security in Elasticsearch and Kibana, thereby eliminating the need to set up user credentials as described above.
 
-To start a container in development mode, set the `DEVELOPMENT_MODE` environment variable to `1`. 
+To start a container in development mode, set the `DEVELOPMENT_MODE` environment variable to `1`.
 
 ### Security considerations
 

--- a/startx.sh
+++ b/startx.sh
@@ -8,7 +8,7 @@
 
 ## handle termination gracefully
 
-_term() { 
+_term() {
   kill -TERM ${child} 2>/dev/null
   wait ${child}
 }
@@ -34,7 +34,7 @@ fi
 if [ "$ELASTIC_BOOTSTRAP_PASSWORD" ]; then
   # set Elasticsearch configuration path
   export ES_PATH_CONF=/etc/elasticsearch
-  
+
   # create Elasticsearch keystore if it doesn't exist
   if [ ! -f $ES_PATH_CONF/elasticsearch.keystore ]; then
     ${ES_HOME}/bin/elasticsearch-keystore create
@@ -57,6 +57,13 @@ if [ "$ELASTIC_BOOTSTRAP_PASSWORD" ]; then
 
   export ELASTICSEARCH_USER=elastic
   export ELASTICSEARCH_PASSWORD=${ELASTIC_BOOTSTRAP_PASSWORD}
+fi
+
+### Add built-in user password to Logstash for X-Pack monitoring
+
+if ! grep -q xpack.monitoring.elasticsearch.password ${LOGSTASH_HOME}/config/logstash.yml
+then
+    echo xpack.monitoring.elasticsearch.password: \${LOGSTASH_PASSWORD} >> ${LOGSTASH_HOME}/config/logstash.yml
 fi
 
 
@@ -86,7 +93,7 @@ if [ -z "$LOGSTASH_START" ] || [ "$LOGSTASH_START" == "1" ]; then
   else
     echo export LOGSTASH_USER=${LOGSTASH_USER} >> /etc/default/logstash
   fi
-  
+
   if grep -Eq "^export LOGSTASH_PASSWORD=" /etc/default/logstash; then
     awk -v LINE="export LOGSTASH_PASSWORD=${LOGSTASH_PASSWORD}" '{ sub(/^export LOGSTASH_PASSWORD=.*/, LINE); print; }' \
       /etc/default/logstash > /etc/default/logstash.new \
@@ -127,7 +134,7 @@ if [ -z "$KIBANA_START" ] || [ "$KIBANA_START" == "1" ]; then
 
     export KIBANA_URL=http://${KIBANA_USER}:${KIBANA_PASSWORD}@localhost:5601
 
-  fi 
+  fi
 fi
 
 
@@ -135,5 +142,5 @@ fi
 
 /usr/local/bin/start.sh &
 
-child=$! 
+child=$!
 wait ${child}


### PR DESCRIPTION
Simplify the X-Pack setup by appending the [`xpack.monitoring.elasticsearch.password` option to logstash.yml](https://www.elastic.co/guide/en/elastic-stack-overview/current/built-in-users.html#add-built-in-user-passwords) (setting it to `${LOGSTASH_PASSWORD}`).

This also addresses an issue I was running into ([and](https://github.com/spujadas/elkx-docker/issues/8#issuecomment-346409975) [others](https://github.com/spujadas/elkx-docker/issues/8#issuecomment-353293966)?) where the `xpack.monitoring` options were intermittently lost after restarting the container.